### PR TITLE
Scanner prints commits with same failure message together (#91)

### DIFF
--- a/detector/detection_results_test.go
+++ b/detector/detection_results_test.go
@@ -25,8 +25,8 @@ func TestCanRecordMultipleErrorsAgainstASingleFile(t *testing.T) {
 	results.Fail("some_filename", "Bomb", []string{})
 	results.Fail("some_filename", "Complete & utter failure", []string{})
 	results.Fail("another_filename", "Complete & utter failure", []string{})
-	assert.Len(t, results.GetFailures("some_filename"), 2, "Expected two errors against some_filename.")
-	assert.Len(t, results.GetFailures("another_filename"), 1, "Expected one error against another_filename")
+	assert.Len(t, results.GetFailures("some_filename").FailuresInCommits, 2, "Expected two errors against some_filename.")
+	assert.Len(t, results.GetFailures("another_filename").FailuresInCommits, 1, "Expected one error against another_filename")
 }
 
 func TestResultsReportsFailures(t *testing.T) {
@@ -35,7 +35,7 @@ func TestResultsReportsFailures(t *testing.T) {
 	results.Fail("some_filename", "Complete & utter failure", []string{})
 	results.Fail("another_filename", "Complete & utter failure", []string{})
 
-	actualErrorReport := results.ReportFileFailures("some_filename", false)
+	actualErrorReport := results.ReportFileFailures("some_filename")
 	fmt.Println(actualErrorReport)
 
 	assert.Regexp(t, "some_filename", actualErrorReport[0][0], "Error report does not contain expected output")

--- a/detector/filecontent_detector_test.go
+++ b/detector/filecontent_detector_test.go
@@ -122,8 +122,8 @@ func TestShouldFlagPotentialSecretsEncodedInHex(t *testing.T) {
 	filePath := additions[0].Path
 
 	NewFileContentDetector().Test(additions, TalismanRCIgnore{}, results)
-	expectedMsg := "Expected file to not to contain hex encoded texts such as: " + hex
-	assert.Equal(t, expectedMsg, results.GetFailures(filePath)[0].Message[0])
+	expectedMessage := "Expected file to not to contain hex encoded texts such as: " + hex
+	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[0])
 }
 
 func TestResultsShouldContainHexTextsIfHexAndBase64ExistInFile(t *testing.T) {
@@ -137,8 +137,8 @@ func TestResultsShouldContainHexTextsIfHexAndBase64ExistInFile(t *testing.T) {
 	filePath := additions[0].Path
 
 	NewFileContentDetector().Test(additions, TalismanRCIgnore{}, results)
-	expectedMsg := "Expected file to not to contain hex encoded texts such as: " + hex
-	assert.Equal(t, expectedMsg, results.GetFailures(filePath)[1].Message[0])
+	expectedMessage := "Expected file to not to contain hex encoded texts such as: " + hex
+	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[1])
 }
 
 func TestResultsShouldContainBase64TextsIfHexAndBase64ExistInFile(t *testing.T) {
@@ -152,8 +152,8 @@ func TestResultsShouldContainBase64TextsIfHexAndBase64ExistInFile(t *testing.T) 
 	filePath := additions[0].Path
 
 	NewFileContentDetector().Test(additions, TalismanRCIgnore{}, results)
-	expectedMsg := "Expected file to not to contain base64 encoded texts such as: " + base64
-	assert.Equal(t, expectedMsg, results.GetFailures(filePath)[0].Message[0])
+	expectedMessage := "Expected file to not to contain base64 encoded texts such as: " + base64
+	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[0])
 }
 
 func TestResultsShouldContainCreditCardNumberIfCreditCardNumberExistInFile(t *testing.T) {
@@ -165,7 +165,14 @@ func TestResultsShouldContainCreditCardNumberIfCreditCardNumberExistInFile(t *te
 	filePath := additions[0].Path
 
 	NewFileContentDetector().Test(additions, TalismanRCIgnore{}, results)
-	expectedMsg := "Expected file to not to contain credit card numbers such as: " +
-		creditCardNumber
-	assert.Equal(t, expectedMsg, results.GetFailures(filePath)[0].Message[0])
+	expectedMessage := "Expected file to not to contain credit card numbers such as: " + creditCardNumber
+	assert.Equal(t, expectedMessage, getFailureMessages(results, filePath)[0])
+}
+
+func getFailureMessages(results *DetectionResults, filePath git_repo.FilePath) []string {
+	failureMessages := []string{}
+	for failureMessage := range results.GetFailures(filePath).FailuresInCommits {
+		failureMessages = append(failureMessages, failureMessage)
+	}
+	return failureMessages
 }

--- a/detector/pattern_detector_test.go
+++ b/detector/pattern_detector_test.go
@@ -36,5 +36,14 @@ func shouldPassDetectionOfSecretPattern(filename string, content []byte, t *test
 	results := NewDetectionResults()
 	additions := []git_repo.Addition{git_repo.NewAddition(filename, content)}
 	NewPatternDetector().Test(additions, TalismanRCIgnore{}, results)
-	assert.Equal(t, "Potential secret pattern : "+string(content), results.GetFailures(additions[0].Path)[0].Message[0])
+	expected := "Potential secret pattern : " + string(content)
+	assert.Equal(t, expected, getFailureMessage(results, additions))
+}
+
+func getFailureMessage(results *DetectionResults, additions []git_repo.Addition) string {
+	failureMessages := []string{}
+	for failureMessage := range results.GetFailures(additions[0].Path).FailuresInCommits {
+		failureMessages = append(failureMessages, failureMessage)
+	}
+	return failureMessages[0]
 }

--- a/report/report.go
+++ b/report/report.go
@@ -279,18 +279,16 @@ func getReportHTML() string {
 							<td>{{$filePath}}</td>
 							<td>
 								<table class="details">
-									{{range $failure := $FailureData}}
+									{{range $failureMessage, $commits := $FailureData.FailuresInCommits}}
 										<tr>
 											<td class="failure-message">
-												{{range $failureMsg := $failure.Message}}
-													{{$failureMsg}}
-												{{end}}
+												{{$failureMessage}}
 											</td>
 											<td>
 												<table>
-													{{range $commit := $failure.Commits}}
-														<tr><td>{{$commit}}</td></tr>
-													{{end}}
+												{{range $commit := $commits}}
+													<tr><td>{{$commit}}</td></tr>
+												{{end}}
 												</table>
 											</td>
 										</tr>


### PR DESCRIPTION
* refactored scanner to print commits with same failure message together

* Fixed tests which were failing after refactoring of scanner

* refactor tests to compare failure messages instead of maps